### PR TITLE
상품 기능 개발 오류 수정

### DIFF
--- a/src/main/kotlin/com/wise/mall/product/adapter/out/persistence/ProductPersistAdapter.kt
+++ b/src/main/kotlin/com/wise/mall/product/adapter/out/persistence/ProductPersistAdapter.kt
@@ -3,8 +3,9 @@ package com.wise.mall.product.adapter.out.persistence
 import com.wise.mall.product.adapter.out.persistence.entity.ProductEntity
 import com.wise.mall.product.adapter.out.persistence.exception.NotExistsProductEntityException
 import com.wise.mall.product.adapter.out.persistence.repository.ProductRepository
-import com.wise.mall.product.application.domain.model.Product
 import com.wise.mall.product.application.port.out.ProductPersistPort
+import com.wise.mall.product.application.vo.CreateProductVo
+import com.wise.mall.product.application.vo.UpdateProductVo
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
@@ -15,23 +16,23 @@ class ProductPersistAdapter (
 ) : ProductPersistPort {
 
     @Transactional
-    override fun createProduct(product: Product) {
+    override fun createProduct(createProductVo: CreateProductVo) {
         productRepository.save(
             ProductEntity(
-                name = product.name,
-                price = product.price,
-                state = 0,
+                name = createProductVo.name,
+                price = createProductVo.price,
+                state = createProductVo.state,
             )
         )
     }
 
     @Transactional
-    override fun updateProduct(product: Product) {
+    override fun updateProduct(updateProductVo: UpdateProductVo) {
 
-        val productEntity = productRepository.findByIdOrNull(product.id)
-            ?: throw NotExistsProductEntityException(id = product.id ?: -1)
+        val productEntity = productRepository.findByIdOrNull(updateProductVo.id)
+            ?: throw NotExistsProductEntityException(id = updateProductVo.id)
 
-        productEntity.updateState(product.state)
+        productEntity.updateState(updateProductVo.state)
 
         productRepository.save(productEntity)
     }

--- a/src/main/kotlin/com/wise/mall/product/application/domain/model/Product.kt
+++ b/src/main/kotlin/com/wise/mall/product/application/domain/model/Product.kt
@@ -4,7 +4,7 @@ import java.time.LocalDateTime
 
 data class Product (
 
-    var id: Long? = null,
+    val id: Long,
 
     var name: String,
 
@@ -12,9 +12,9 @@ data class Product (
 
     var state: Int,
 
-    var createdAt: LocalDateTime? = null,
+    val createdAt: LocalDateTime,
 
-    var updatedAt: LocalDateTime? = null,
+    val updatedAt: LocalDateTime,
 ) {
     /**
      * 상품 등록 허가

--- a/src/main/kotlin/com/wise/mall/product/application/port/out/ProductPersistPort.kt
+++ b/src/main/kotlin/com/wise/mall/product/application/port/out/ProductPersistPort.kt
@@ -1,10 +1,11 @@
 package com.wise.mall.product.application.port.out
 
-import com.wise.mall.product.application.domain.model.Product
+import com.wise.mall.product.application.vo.CreateProductVo
+import com.wise.mall.product.application.vo.UpdateProductVo
 
 interface ProductPersistPort {
 
-    fun createProduct(product: Product)
+    fun createProduct(createProductVo: CreateProductVo)
 
-    fun updateProduct(product: Product)
+    fun updateProduct(updateProductVo: UpdateProductVo)
 }

--- a/src/main/kotlin/com/wise/mall/product/application/service/ProductService.kt
+++ b/src/main/kotlin/com/wise/mall/product/application/service/ProductService.kt
@@ -8,6 +8,8 @@ import com.wise.mall.product.application.port.`in`.ProductUseCase
 import com.wise.mall.product.application.port.`in`.command.*
 import com.wise.mall.product.application.port.out.ProductPersistPort
 import com.wise.mall.product.application.port.out.ProductReadPort
+import com.wise.mall.product.application.vo.CreateProductVo
+import com.wise.mall.product.application.vo.UpdateProductVo
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -26,7 +28,7 @@ class ProductService (
         }
 
         productPersistPort.createProduct(
-            product = Product(
+            createProductVo = CreateProductVo(
                 name = command.name,
                 price = command.price,
                 state = 0,
@@ -54,13 +56,11 @@ class ProductService (
 
         // 거절 상태가 아닌 경우
         if (product.state != -1) {
-            product.id?.let { id ->
-                throw InvalidStateException(id = id)
-            }
+            throw InvalidStateException(id = product.id)
         }
 
         productPersistPort.updateProduct(
-            product = product
+            updateProductVo = UpdateProductVo.of(product)
         )
     }
 
@@ -72,7 +72,7 @@ class ProductService (
         product.approvalAllow()
 
         productPersistPort.updateProduct(
-            product = product
+            updateProductVo = UpdateProductVo.of(product)
         )
     }
 
@@ -84,7 +84,7 @@ class ProductService (
         product.approvalDeny()
 
         productPersistPort.updateProduct(
-            product = product
+            updateProductVo = UpdateProductVo.of(product)
         )
     }
 }

--- a/src/main/kotlin/com/wise/mall/product/application/vo/CreateProductVo.kt
+++ b/src/main/kotlin/com/wise/mall/product/application/vo/CreateProductVo.kt
@@ -1,0 +1,10 @@
+package com.wise.mall.product.application.vo
+
+data class CreateProductVo(
+
+    val name: String,
+
+    val price: Int,
+
+    val state: Int,
+)

--- a/src/main/kotlin/com/wise/mall/product/application/vo/UpdateProductVo.kt
+++ b/src/main/kotlin/com/wise/mall/product/application/vo/UpdateProductVo.kt
@@ -1,0 +1,23 @@
+package com.wise.mall.product.application.vo
+
+import com.wise.mall.product.application.domain.model.Product
+
+data class UpdateProductVo(
+
+    val id: Long,
+
+    val name: String,
+
+    val price: Int,
+
+    val state: Int,
+) {
+    companion object {
+        fun of(product: Product): UpdateProductVo = UpdateProductVo(
+            id = product.id,
+            name = product.name,
+            price = product.price,
+            state = product.state,
+        )
+    }
+}


### PR DESCRIPTION
## 개요
- 상품 등록 Vo, 상품 수정 Vo 생성

## 설명
- 기존에 Domain Layer 에서 상위 Adapter Layer로의 데이터 전달 객체를 Product (Domain 객체)로 통일한 경우 코드의 복잡성이 높아지는 문제점이 있을 것 같아 수정해 보았습니다.
- #1 의 변경 사항 처럼 Product 를 통일하여 사용할 때, 상품 등록의 경우 필요 없는 필드인 ```id```, ```createdAt```, ```updatedAt```필드는```nullable``` 필드로 설정해야 합니다. 이렇게 하면 상품 조회나 상품 수정하는 경우에 null 여부를 체크하는 코드가 반복적으로 발생할 것으로 생각됩니다. 
- out adapter 로 전달하는 데이터가 완전히 다른 상품 등록과 상품 수정의 경우 별도의 Vo로 분리하여 전달하는 것이 좀 더 효율적이라고 판단하여 변경했습니다.

ps. 위 변경 사항과 관련하여 피드백 코멘트로 부탁드립니다! :)